### PR TITLE
[Blending] OpenCV - SeamlessClone Method

### DIFF
--- a/syntheticdataset/image_blending.py
+++ b/syntheticdataset/image_blending.py
@@ -64,9 +64,10 @@ def poisson_blending(img, smoke, offset=(0, 0)):
 
     return result, mask
 
-def seamless_clone_blending(img, smoke, offset=(0,0), clone_type = cv2.MIXED_CLONE):
+
+def seamless_clone_blending(img, smoke, offset=(0, 0), clone_type=cv2.MIXED_CLONE):
     """Add smoke on image using OpenCV with SeamlessClone method
-    
+
     Args:
         img (np.array): background image
         smoke (np.array): smoke image
@@ -77,7 +78,7 @@ def seamless_clone_blending(img, smoke, offset=(0,0), clone_type = cv2.MIXED_CLO
         _type_: _description_
     """
 
-    mask = (( smoke > 0 ) * 255).astype('uint8')
+    mask = ((smoke > 0) * 255).astype("uint8")
 
     blended_img = cv2.seamlessClone(smoke, img, mask, offset, clone_type)
 


### PR DESCRIPTION
This PR : 
- adds a new blending method from openCV : `seamlessClone`
- creates an iteration process to test different blending methods  

A quick example for `seamlessClone` : 

![set_000_0022](https://user-images.githubusercontent.com/33042009/164279194-3a90df64-414d-4265-bfd0-093c1a344582.png)

